### PR TITLE
feat: Add find-doc-save-hooks.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Need to run as root user
 Run from the bench root (it greps `./apps`). Prompts for a site name.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/frappe/fc-scripts/refs/heads/develop/find-doc-save-hooks.sh -o find-doc-save-hooks.sh && bash find-doc-save-hooks.sh
+curl -fsSL https://raw.githubusercontent.com/frappe/fc-scripts/refs/heads/develop/find-doc-save-hooks.sh | bash
 ```
 
 ### MariaDB IO Monitor Installation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Helper scripts to be run on Frappe Cloud sites
 - Read the deadlocks from mariadb error log [analyze_deadlocks.py](./analyze_deadlocks.py)
 - Check corruption in MariaDB tables and fix them [check_db_tables.sh](./check_db_tables.sh)
 - On premises failover manager setup script [press-on-prem-failover.sh](./press-on-prem-failover.sh)
+- Find app-side document save hooks that make saving slow [find-doc-save-hooks.sh](./find-doc-save-hooks.sh)
 
 ---
 
@@ -50,6 +51,14 @@ Need to run as root user
 ./check_db_tables.sh <database_name>
 ```
 
+
+### Doc Save Hooks Finder
+
+Run from the bench root (it greps `./apps`). Prompts for a site name.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/frappe/fc-scripts/refs/heads/develop/find-doc-save-hooks.sh -o find-doc-save-hooks.sh && bash find-doc-save-hooks.sh
+```
 
 ### MariaDB IO Monitor Installation
 

--- a/find-doc-save-hooks.sh
+++ b/find-doc-save-hooks.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Find slow document save hooks users blame on the platform.
-# Run from bench root:  bash apps/press/server-scripts/find-doc-save-hooks.sh
+# Run from bench root:  bash find-doc-save-hooks.sh
 set -uo pipefail
 
 read -rp "Site name: " SITE

--- a/find-doc-save-hooks.sh
+++ b/find-doc-save-hooks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Find slow document save hooks users blame on the platform.
+# Run from bench root:  bash apps/press/server-scripts/find-doc-save-hooks.sh
+set -uo pipefail
+
+read -rp "Site name: " SITE
+
+SKIP='{frappe,print_designer,india_compliance,drive,hrms,erpnext,lms,helpdesk,builder,insights,wiki,payments}'
+
+echo "== Controller lifecycle methods =="
+eval grep -rn -A 10 --exclude-dir="$SKIP" \
+  -E "'def (validate|before_save|after_save|before_insert|after_insert|on_update|on_change|on_submit|before_submit|on_trash|before_validate)\('" \
+  ./apps --include='*.py'
+
+echo "== doc_events in hooks.py =="
+eval grep -rn -A 10 --exclude-dir="$SKIP" 'doc_events' ./apps --include='hooks.py'
+
+echo "== Enabled Server Scripts with loops on common ERPNext doctypes =="
+bench --site "$SITE" console <<'PY'
+import re
+rows = frappe.get_all("Server Script",
+    filters={"disabled": 0, "reference_doctype": ["in",
+        ["Sales Order","Item","Job Card","Sales Invoice","Purchase Order","Stock Entry","Delivery Note"]]},
+    fields=["name","reference_doctype","doctype_event","script"])
+for r in rows:
+    if re.search(r"\b(for|while)\b", r.script or ""):
+        print(r.name, "|", r.reference_doctype, "|", r.doctype_event)
+PY

--- a/find-doc-save-hooks.sh
+++ b/find-doc-save-hooks.sh
@@ -3,7 +3,7 @@
 # Run from bench root:  bash find-doc-save-hooks.sh
 set -uo pipefail
 
-read -rp "Site name: " SITE
+read -rp "Site name: " SITE </dev/tty
 
 SKIP='{frappe,print_designer,india_compliance,drive,hrms,erpnext,lms,helpdesk,builder,insights,wiki,payments}'
 


### PR DESCRIPTION
Surfaces app-side document save hooks that make saving feel slow. Users often blame the platform when the real cost is an app.

The script:
- greps custom apps (skips heavy stock apps) for controller lifecycle methods and `doc_events`
- prompts for a site, then lists **enabled** Server Scripts with loops on common ERPNext doctypes (Sales Order, Item, Job Card, ...)

Run on a server: `bash find-doc-save-hooks.sh` from the bench root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)